### PR TITLE
Added exit states to all examples so the streams get closed when done.

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -46,3 +46,8 @@ void ofApp::draw()
     ofSetColor(255);
     vidGrabber.draw(0, 0);
 }
+
+void ofApp::exit()
+{
+    vidGrabber.close();
+}

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -35,6 +35,7 @@ public:
     void setup();
     void update();
     void draw();
+    void exit();
 
     ofVideoGrabber vidGrabber;
 

--- a/example_advanced/src/ofApp.cpp
+++ b/example_advanced/src/ofApp.cpp
@@ -86,3 +86,8 @@ void ofApp::draw()
     ofDrawBitmapStringHighlight(ss.str(), ofPoint(10, 15));
 
 }
+
+void ofApp::exit()
+{
+    vidGrabber.close();
+}

--- a/example_advanced/src/ofApp.h
+++ b/example_advanced/src/ofApp.h
@@ -36,6 +36,7 @@ public:
     void setup();
     void update();
     void draw();
+    void exit();
 
     ofxPS3EyeGrabber vidGrabber;
     ofTexture videoTexture;

--- a/example_advanced_multicam/src/ofApp.cpp
+++ b/example_advanced_multicam/src/ofApp.cpp
@@ -116,3 +116,11 @@ void ofApp::draw()
         }
     }
 }
+
+void ofApp::exit()
+{
+    for(std::size_t i = 0; i < videoGrabbers.size(); ++i)
+    {
+        videoGrabbers[i]->close();
+    }
+}

--- a/example_advanced_multicam/src/ofApp.h
+++ b/example_advanced_multicam/src/ofApp.h
@@ -36,6 +36,7 @@ public:
     void setup();
     void update();
     void draw();
+    void exit();
 
     std::vector<std::shared_ptr<ofxPS3EyeGrabber> > videoGrabbers;
     std::vector<ofTexture> videoTextures;


### PR DESCRIPTION
I was playing the examples and realized the streams were being left open so I added the exit() and vidgrabber.close() for all three.